### PR TITLE
Add configurability (and documentation) to environment model

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ socket << "GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n"
 socket.gets # => "HTTP/1.1 200 OK\r\n"
 ```
 
+### Environment - patching TCPSocket
+
+```ruby
+require 'proxifier/env'
+ENV['PROXY'] = 'http://10.0.0.44:8888' # How to find the proxy
+ENV['PROXY_FILTER_REGEX'] = '(10\..*|localhost)' # Do not use proxy for connections inside internal net or localhost
+ENV['PROXY_FILTER_LIST'] = '66.211.168.123,207.97.227.239'
+```
+
+Afterwards, any new TCPSocket connections will use the proxy, unless they're excluded either by the specific PROXY_FILTER_LIST or the PROXY_FILTER_REGEX.
+
+PROXY_FILTER_LIST specifies a comma separated list of hostnames or IP addresses (whichever the client code is going to use).
+
+PROXY_FILTER_REGEX is a regular expression, where if the connection hostname (or IP address) matches the regex, connections will be made directly and not through the proxy.
+
+Both PROXY_FILTER_LIST and PROXY_FILTER_REGEX are optional, but only one will be used.
+
 ## Supported Proxies
 
 <table>

--- a/lib/proxifier/env.rb
+++ b/lib/proxifier/env.rb
@@ -36,6 +36,12 @@ module Proxifier
         options = options_if_local_host
       end
 
+      if ENV['PROXY_FILTER_REGEX'].present?
+        options[:no_proxy] = /\A#{ENV['PROXY_FILTER_REGEX']}\z/
+      elsif ENV['PROXY_FILTER_LIST'].present?
+        options[:no_proxy] = ENV['PROXY_FILTER_LIST']
+      end
+
       if options[:proxy] && (proxy = Proxifier::Proxy(options.delete(:proxy), options)) && proxy.proxify?(host)
         initialize_without_proxy(proxy.host, proxy.port, local_host, local_port)
         begin

--- a/lib/proxifier/proxy.rb
+++ b/lib/proxifier/proxy.rb
@@ -8,8 +8,12 @@ module Proxifier
       def proxify?(host, no_proxy = nil)
         return true unless no_proxy
 
-        dont_proxy = no_proxy.split(",")
-        dont_proxy.none? { |h| host =~ /#{h}\Z/ }
+        if no_proxy.is_a?(Regexp)
+          (host =~ no_proxy).nil?
+        else
+          dont_proxy = no_proxy.split(",")
+          dont_proxy.none? { |h| host =~ /#{h}\Z/ }
+        end
       end
     end
 


### PR DESCRIPTION
In my environment I want all TCPConnections to go through the proxy if they're bound for the real internet (say, paypal), but not if they're staying inside my firewalled net (memcached, etc.)

This allows that.

Environment variable PROXY_FILTER_LIST is a comma separated list of hosts (or IPs) to not use the proxy with
  (e.g. '10.0.0.1,10.0.2.1')

Environment variable PROXY_FILTER_REGEXP is a regular expression, where if the host matches, it connects directly, not through the proxy
  (e.g., '(10..*|localhost)')
