### PR TITLE
Fixes for Proxy creation from URL String and SOCKS5 authentication

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,10 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+task default: :test
+
+Rake::TestTask.new do |task|
+  task.libs << 'lib' << 'spec'
+  task.pattern = 'spec/**/*_spec.rb'
+  task.verbose = true
+end

--- a/lib/proxifier/proxies/socks.rb
+++ b/lib/proxifier/proxies/socks.rb
@@ -3,7 +3,8 @@ require "proxifier/proxy"
 
 module Proxifier
   class SOCKSProxy < Proxy
-    VERSION = 0x05
+    VERSION                = 0x05
+    SUBNEGOTIATION_VERSION = 0x01
 
     def do_proxify(socket, host, port)
       authenticaton_method = greet(socket)
@@ -26,12 +27,12 @@ module Proxifier
         case method
         when 0x00 # NO AUTHENTICATION REQUIRED
         when 0x02 # USERNAME/PASSWORD
-          user &&= user[0, 0xFF]
-          password &&= password[0, 0xFF]
+          _user     = user ? user[0, 0xFF] : ''
+          _password = password ? password[0, 0xFF] : ''
 
-          socket << [user.size, user, password.size, password].pack("CA#{user.size}CA#{password.size}")
-          version, status = socket.read(2).unpack("CC")
-          check_version(version)
+          socket << [SUBNEGOTIATION_VERSION, _user.size, _user, _password.size, _password].pack("CCA#{_user.size}CA#{_password.size}")
+          version, status = socket.read(2).unpack('CC')
+          check_version(version, SUBNEGOTIATION_VERSION)
 
           case status
             when 0x00 # SUCCESS

--- a/lib/proxifier/proxy.rb
+++ b/lib/proxifier/proxy.rb
@@ -16,7 +16,7 @@ module Proxifier
     attr_reader :url, :options
 
     def initialize(url, options = {})
-      url = URI.parse(uri) unless url.is_a?(URI::Generic)
+      url = URI.parse(url) unless url.is_a?(URI::Generic)
       @url, @options = url, options
     end
 

--- a/lib/proxifier/version.rb
+++ b/lib/proxifier/version.rb
@@ -1,3 +1,3 @@
 module Proxifier
-  VERSION = "1.0.3"
+  VERSION = '1.0.4'
 end

--- a/proxifier.gemspec
+++ b/proxifier.gemspec
@@ -13,4 +13,6 @@ Gem::Specification.new do |s|
 
   s.files       = Dir["bin/*", "lib/**/*"] + ["LICENSE", "README.md"]
   s.executables = ["pirb", "pruby"]
+
+  s.add_development_dependency 'minitest', '>= 4.6.0'
 end

--- a/spec/proxifier/proxies/socks_spec.rb
+++ b/spec/proxifier/proxies/socks_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'uri'
+require 'proxifier/proxies/socks'
+
+describe Proxifier::SOCKSProxy do
+
+  before do
+    @socket = MiniTest::Mock.new
+  end
+
+  it 'should comply with SOCKS5 authentication specification' do
+    proxy = Proxifier::Proxy('socks://joe:sekret@myproxy:60123')
+
+    proxy.must_be_instance_of Proxifier::SOCKSProxy
+
+    TCPSocket.stub :new, @socket do
+      @socket.expect :<<, nil, ["\x05\x02\x00\x02"]
+      @socket.expect :read, "\x05\x02", [2]
+      @socket.expect :<<, nil, ["\x01\x03joe\x06sekret"]
+      @socket.expect :read, "\x01\x00", [2]
+      @socket.expect :<<, nil, ["\x05\x01\x00\x03\tlocalhost\x048"]
+      @socket.expect :read, "\x05\x00\x00\x01", [4]
+      @socket.expect :read, "\x7F\x00\x00\x01", [4]
+      @socket.expect :read, "\x08", [2]
+
+      proxy.open('localhost', 1080)
+    end
+  end
+
+end

--- a/spec/proxifier/proxy_spec.rb
+++ b/spec/proxifier/proxy_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'uri'
+require 'proxifier/proxy'
+
+describe Proxifier::Proxy do
+
+  it 'should create proxy from URL String' do
+    proxy = Proxifier::Proxy.new('socks://joe:sekret@myproxy:60123')
+
+    proxy.url.scheme.must_equal 'socks'
+    proxy.user.must_equal 'joe'
+    proxy.password.must_equal 'sekret'
+    proxy.host.must_equal 'myproxy'
+    proxy.port.must_equal 60123
+  end
+
+  it 'should create proxy from generic URI' do
+    uri   = URI::Generic.new('socks', 'joe:sekret', 'myproxy', 60123, nil, nil, nil, nil, nil)
+    proxy = Proxifier::Proxy.new(uri)
+
+    proxy.url.scheme.must_equal 'socks'
+    proxy.user.must_equal 'joe'
+    proxy.password.must_equal 'sekret'
+    proxy.host.must_equal 'myproxy'
+    proxy.port.must_equal 60123
+  end
+
+end

--- a/spec/proxifier_spec.rb
+++ b/spec/proxifier_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'proxifier/proxies/socks'
+
+describe Proxifier do
+
+  it 'should have a version number' do
+    Proxifier::VERSION.wont_be_nil
+  end
+
+  it 'should create Proxy from URL String' do
+    proxy = Proxifier::Proxy('socks://joe:sekret@myproxy:60123')
+
+    proxy.must_be_instance_of Proxifier::SOCKSProxy
+    proxy.user.must_equal 'joe'
+    proxy.password.must_equal 'sekret'
+    proxy.host.must_equal 'myproxy'
+    proxy.port.must_equal 60123
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'rubygems'
+
+gem 'minitest' # ensure we are using the gem version
+require 'minitest/spec'
+require 'minitest/autorun'
+
+require 'proxifier'


### PR DESCRIPTION
- Fixed Proxifier::Proxy creation from URL String (`Proxifier::Proxy.new('socks://user:password@domain:port')`).
- Fixed SOCKS5 authentication (it lacked subnegotiation version required by protocol specified in [RFC 1928](http://www.ietf.org/rfc/rfc1928.txt) and [RFC 1929](http://www.ietf.org/rfc/rfc1929.txt)).
- Added tests for above fixes.
