### PR TITLE
Make gem compatible with ruby 1.8.7

### DIFF
--- a/bin/pirb
+++ b/bin/pirb
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
+require 'rubygems'
 
 executable = File.expand_path("../" + Gem.default_exec_format % "irb", Gem.ruby)
 full_gem_path = Gem.loaded_specs["proxifier"].full_gem_path
 load_paths = Gem.loaded_specs["proxifier"].require_paths.map { |p| "-I#{File.join(full_gem_path, p)}" }
 # TODO: support argument switches
 
-exec(executable, *load_paths, "-rproxifier/env", *ARGV)
+params = [executable, load_paths,  "-rproxifier/env", ARGV].flatten(1)
+exec(*params)

--- a/bin/pruby
+++ b/bin/pruby
@@ -1,8 +1,11 @@
 #!/usr/bin/env ruby
+require 'rubygems'
 
 executable = Gem.ruby
 full_gem_path = Gem.loaded_specs["proxifier"].full_gem_path
 load_paths = Gem.loaded_specs["proxifier"].require_paths.map { |p| "-I#{File.join(full_gem_path, p)}" }
 # TODO: support argument switches
 
-exec(executable, *load_paths, "-rproxifier/env", *ARGV)
+params = [executable, load_paths,  "-rproxifier/env", ARGV].flatten(1)
+exec(*params)
+


### PR DESCRIPTION
I don't know if you are willing to add support for 1.8.7, but with a couple of changes in both executables the gem seems to be valid ruby 1.8.7. So far on my testing (only of the http proxy) everything else works fine, and ruby -c raises no errors.
