### PR TITLE
Allow customizing User-Agent header (HTTP only).

### DIFF
--- a/lib/proxifier/proxies/http.rb
+++ b/lib/proxifier/proxies/http.rb
@@ -9,6 +9,7 @@ module Proxifier
       socket << "CONNECT #{host}:#{port} HTTP/1.1\r\n"
       socket << "Host: #{host}:#{port}\r\n"
       socket << "Proxy-Authorization: Basic #{["#{user}:#{password}"].pack("m").chomp}\r\n" if user
+      socket << "User-Agent: #{user_agent}\r\n" if user_agent
       socket << "\r\n"
 
       buffer = Net::BufferedIO.new(socket)

--- a/lib/proxifier/proxy.rb
+++ b/lib/proxifier/proxy.rb
@@ -51,7 +51,7 @@ module Proxifier
       @query_options ||= query ? Hash[query.split("&").map { |q| q.split("=") }] : {}
     end
 
-    %w(no_proxy).each do |option|
+    %w(no_proxy user_agent).each do |option|
       class_eval "def #{option}; options[:#{option}] end"
     end
 


### PR DESCRIPTION
This commit adds a `:user_agent` option that can be used to configure the HTTP User-Agent header that proxifier presents to HTTP proxy servers.