### PR TITLE
Fix local variable reference

### DIFF
--- a/lib/proxifier/proxy.rb
+++ b/lib/proxifier/proxy.rb
@@ -16,7 +16,7 @@ module Proxifier
     attr_reader :url, :options
 
     def initialize(url, options = {})
-      url = URI.parse(uri) unless url.is_a?(URI::Generic)
+      url = URI.parse(url) unless url.is_a?(URI::Generic)
       @url, @options = url, options
     end
 


### PR DESCRIPTION
Usually it looks like instances of `Proxy` are created with an instance of `URI`, but if you're like me and you tried to instantiate one by hand with a string, you get a `NameError` in response. The problem is that `url` is passed into the constructor but `URI.parse` is passed a variable named `uri`, which doesn't exist. Not a problem if you instantiate proxies the right way™, but still a bug :)