### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/proxifier.rb
+++ b/lib/proxifier.rb
@@ -1,8 +1,8 @@
 require "uri"
-require "uri/socks"
+require_relative "uri/socks"
 
 module Proxifier
-  require "proxifier/version"
+  require_relative "proxifier/version"
 
   autoload :HTTPProxy, "proxifier/proxies/http"
   autoload :SOCKSProxy, "proxifier/proxies/socks"

--- a/lib/proxifier/env.rb
+++ b/lib/proxifier/env.rb
@@ -1,5 +1,5 @@
 require "socket"
-require "proxifier"
+require_relative "../proxifier"
 
 module Proxifier
   class Proxy

--- a/lib/proxifier/proxies/http.rb
+++ b/lib/proxifier/proxies/http.rb
@@ -1,5 +1,5 @@
 require "net/http"
-require "proxifier/proxy"
+require_relative "../proxy"
 
 module Proxifier
   class HTTPProxy < Proxy

--- a/lib/proxifier/proxies/socks.rb
+++ b/lib/proxifier/proxies/socks.rb
@@ -1,5 +1,5 @@
 require "ipaddr"
-require "proxifier/proxy"
+require_relative "../proxy"
 
 module Proxifier
   class SOCKSProxy < Proxy

--- a/lib/proxifier/proxies/socks4.rb
+++ b/lib/proxifier/proxies/socks4.rb
@@ -1,4 +1,4 @@
-require "proxifier/proxies/socks"
+require_relative "socks"
 
 module Proxifier
   class SOCKS4Proxy < SOCKSProxy

--- a/lib/proxifier/proxies/socks4a.rb
+++ b/lib/proxifier/proxies/socks4a.rb
@@ -1,4 +1,4 @@
-require "proxifier/proxies/socks"
+require_relative "socks"
 
 module Proxifier
   class SOCKS4AProxy < SOCKSProxy

--- a/lib/proxifier/proxy.rb
+++ b/lib/proxifier/proxy.rb
@@ -1,6 +1,6 @@
 require "socket"
 require "uri"
-require "uri/socks"
+require_relative "../uri/socks"
 
 module Proxifier
   class Proxy


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>