### PR TITLE
Use strict Base64 encoding to prevent bad requests

### DIFF
--- a/lib/proxifier/proxies/http.rb
+++ b/lib/proxifier/proxies/http.rb
@@ -1,5 +1,6 @@
 require "net/http"
 require "proxifier/proxy"
+require 'base64'
 
 module Proxifier
   class HTTPProxy < Proxy
@@ -8,7 +9,7 @@ module Proxifier
 
       socket << "CONNECT #{host}:#{port} HTTP/1.1\r\n"
       socket << "Host: #{host}:#{port}\r\n"
-      socket << "Proxy-Authorization: Basic #{["#{user}:#{password}"].pack("m").chomp}\r\n" if user
+      socket << "Proxy-Authorization: Basic #{Base64.strict_encode64("#{user}:#{password}").chomp}\r\n" if user
       socket << "\r\n"
 
       buffer = Net::BufferedIO.new(socket)


### PR DESCRIPTION
With `Array#pack`, if the credentials is too long, it ends up adding a
new line in the middle of the resulting base64 encoded string, which results in
a 400 Bad Request. To fix this, `Base64.strict_encode64` should be used.

Bad:

```
CONNECT blah:80 HTTP/1.1
Proxy-Authorization: Basic YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhOmJiYmJiYmJiYmJiYmJi
YmJiYmJi
...
```

Good:

```
CONNECT blah:80 HTTP/1.1
Proxy-Authorization: Basic YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhOmJiYmJiYmJiYmJiYmJiYmJiYmJi
...
```